### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,14 +40,7 @@ If you like asciidoc more than markdown, this plugin is exactly for you.
 1. Add `nuxt-asciidoc` dependency to your project
 
 ```bash
-# Using pnpm
-pnpm add -D nuxt-asciidoc
-
-# Using yarn
-yarn add --dev nuxt-asciidoc
-
-# Using npm
-npm install --save-dev nuxt-asciidoc
+npx nuxi@latest module add nuxt-asciidoc
 ```
 
 2. Add `nuxt-asciidoc` to the `modules` section, before the `@nuxt/content`  of `nuxt.config.ts`


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
